### PR TITLE
Add button works differently for single fieldset.

### DIFF
--- a/fields/builder/assets/css/builder.css
+++ b/fields/builder/assets/css/builder.css
@@ -71,6 +71,9 @@
 .drop-down .drop-down-toggle{
   position: relative;
 }
+.drop-down-toggle {
+  cursor: pointer;
+}
 .drop-down ul li{
   border-top: 1px solid #202020;
 }

--- a/fields/builder/assets/js/builder.js
+++ b/fields/builder/assets/js/builder.js
@@ -165,9 +165,13 @@
     };
 
     this.toggleDropDown = function() {
-      console.log('click');
-      $(this).parents('.drop-down').toggleClass('active');
-    }
+      if ( !$(this).parents('.drop-down').hasClass('active') && $(this).next('ul').children('li').length < 2 ) {
+        // If this is your only fieldset, it'll skip the dropdown option and give you a new template for the only fieldset.
+        $(this).next('ul').children('li').first().children('a').click();
+      } else {
+        $(this).parents('.drop-down').toggleClass('active');
+      }
+    };
 
     return this.init();
 

--- a/fields/builder/builder.php
+++ b/fields/builder/builder.php
@@ -74,9 +74,14 @@ class BuilderField extends BaseField {
       $fieldName = $this->name;
       $blueprint  = blueprint::find($this->page());
       $fieldsets = $blueprint->fields()->$fieldName->fieldsets;
+      $fieldsetcount = count($blueprint->fields()->$fieldName->fieldsets);
 
       $addDropdownHtml = '<div class="drop-down">';
-      $addDropdownHtml .= '<a class="drop-down-toggle label-option"><i class="icon icon-left fa fa-chevron-circle-down"></i>' . l('fields.structure.add') . '</a>';
+      if ($fieldsetcount > 1 ) {
+        $addDropdownHtml .= '<a class="drop-down-toggle label-option"><i class="icon icon-left fa fa-chevron-circle-down"></i>' . l('fields.structure.add') . '</a>';
+      } else {
+        $addDropdownHtml .= '<a class="drop-down-toggle label-option"><i class="icon icon-left fa fa-plus-circle"></i>' . l('fields.structure.add') . '</a>';
+      }
       $addDropdownHtml .= '<ul>';
       foreach ($fieldsets as $fieldsetName => $fieldsetFields) {
         $addDropdownHtml .= '<li>';


### PR DESCRIPTION
I've been using this plugin myself, and the one bit of weirdness I've had is that my builders all contain only one fieldset, so the dropdown becomes an unnecessary step.

I've tweaked the files slightly so that, if you've only got the one fieldset, the `Add` button will just automatically fire on the first one. Also I changed the icon to a + in this case. And while I was at it, cursor:pointer on the add button.

Hope that's helpful!