### PR TITLE
submitting updated data by POST instead of GET

### DIFF
--- a/assets/js/builder.js
+++ b/assets/js/builder.js
@@ -97,12 +97,15 @@
   $(document).on('click', '.quickform .btn-submit', function(e){
     e.preventDefault();
     var fieldID = $(this).closest('.builder-entry').find('.builder-entry-quickform-container').data('quickform-container')
-    var data = $('.quickform form').serialize().split(fieldID + '-').join('');
-    var url = $('.quickform form').attr('action')
-    var urlParamSeparator = (url.indexOf('?') > -1) ? '&' : '?'
+    var data = $('.quickform form').serializeArray();
+    var url = $('.quickform form').attr('action');
+    $.each(data, function() {
+      this.name = this.name.replace(fieldID+'-', '');
+    });
     $.ajax({
       type: "POST",
-      url: url + urlParamSeparator + data,
+      url: url,
+      data: data,
       success: function(){
         app.content.reload();
       }


### PR DESCRIPTION
Hi there,
I've made a little bug fix to way how data are sent to server after submitting quickform.

To this moment data were appended to the URL and send by GET, but it can be problematic when you try to send more than 2KB~8KB (http://stackoverflow.com/a/2659995/2171610).

Sending them with POST fixed that, but you **HAVE TO** use `Object` or `Array` to pass the form data to jQuery `$.ajax`. Otherwise Kirby jQuery `ajaxPrefilter` will replace them with `csrf` token (will try to fix this in Kirby Panel also).

Thanks,
Martin

