### PR TITLE
Create .gitignore to ignore node's modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Numerous always-ignore extensions
+*.diff
+*.err
+*.log
+*.orig
+*.rej
+*.swo
+*.swp
+*.vi
+*.zip
+*~
+
+# OS folders
+._*
+.cache
+.DS_Store
+Thumbs.db
+
+# Folders to ignore
+/node_modules


### PR DESCRIPTION
The `node_modules` folder should be installed locally and not distributed through this repository. 🙂 