### PR TITLE
Pass endpoints object from field set to fields

### DIFF
--- a/src/components/BuilderBlock.vue
+++ b/src/components/BuilderBlock.vue
@@ -255,7 +255,9 @@ export default {
         fieldSet.fields[fieldName].endpoints = {
           field: `kirby-builder/pages/${this.encodedPageId}/fields/${
             this.blockPath
-          }+${fieldSet.fields[fieldName].name}`
+          }+${fieldSet.fields[fieldName].name}`,
+          model: fieldSet.endpoints.model,
+          section: fieldSet.endpoints.section
         };
         fieldSet.fields[fieldName].parentPath = this.blockPath;
       });

--- a/src/components/BuilderField.vue
+++ b/src/components/BuilderField.vue
@@ -341,6 +341,7 @@ export default {
     },
     newBlock(fieldSet, key, content, uniqueKey) {
       return {
+        endpoints: this.endpoints,
         fields: fieldSet.fields ? fieldSet.fields : null,
         tabs: fieldSet.tabs ? fieldSet.tabs : null,
         blockKey: key,


### PR DESCRIPTION
Fields within a field set might need the contents of the `endpoints` object in order to work correctly.

This merge request will:

1. Pass the `endpoints` object from `BuilderField` to new `BuilderBlocks`.
2. Pass the properties `model` and `section` from `BuilderBlock`'s field set to each of its fields