### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "timoetting/kirby-builder",
-  "type": "plugin",
+  "type": "kirby-plugin",
   "version": "2.0.7",
   "description": "This versatile plugin for Kirby CMS (v3) lets you predefine content blocks with different field sets that can then be added, edited and arranged inside Kirby's panel.",
   "license": "MIT",
@@ -28,6 +28,7 @@
     "builder"
   ],
   "require": {
-    "php": ">=7.1.0"
+    "php": ">=7.1.0",
+    "getkirby/composer-installer": "^1.1"
   }
 }


### PR DESCRIPTION
Necessary change to make kirby recognize kirby-builder as kirby plugin. This facilitates automatic and correct installation of kirby-builder to site/plugins or optionally a custom plugin path configured in composer.json:
`"extra": { 
  "kirby-plugin-path": "custom/plugin/path"
}`

See https://getkirby.com/docs/cookbook/installation/composer#using-composer-for-kirby-plugins